### PR TITLE
Update background.js with support for copilot.microsoft.com

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -21,7 +21,7 @@ browser.webRequest.onBeforeSendHeaders.addListener(
 
         return { requestHeaders: details.requestHeaders };
     },
-    { urls: ["*://*.bing.com/*"] },
+    { urls: ["*://*.bing.com/*", "*://*copilot.microsoft.com/*"] },
     ["blocking", "requestHeaders"]
 );
 


### PR DESCRIPTION
MS is rebranding future development of Bing Chat as CoPilot, thus suggesting this modification to the list of URLs that will apply the script on the CoPilot url as well.